### PR TITLE
I had all sorts of cascading errors (eg rails.rb:4:in `dirname': can't co

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use  1.9.2@shoppingcart
+rvm use  1.9.2-p180@shoppingcart


### PR DESCRIPTION
I had all sorts of cascading errors (eg rails.rb:4:in `dirname': can't convert nil into String (TypeError)) with 1.9.2-p290. Going to p180 fixed them all, which is also what I saw in your presentation. Didn't dig through the why but thought it would help to have this "just work"
